### PR TITLE
Disabled Dagger UX for cell interpreters that are non-dagger

### DIFF
--- a/src/extension/utils.ts
+++ b/src/extension/utils.ts
@@ -210,8 +210,8 @@ export function getKeyInfo(
     //   return { key: 'daggerCall', resource: 'DaggerObject' }
     // }
 
-    const frontmatterShell = parsedNotebookFrontmatter?.shell ?? ''
-    if (!cellAnnotations.background && isDaggerShell(frontmatterShell)) {
+    const customShell = cellAnnotations.interpreter || parsedNotebookFrontmatter?.shell || ''
+    if (!cellAnnotations.background && isDaggerShell(customShell)) {
       return { key: 'daggerShell', resource: 'None' }
     }
 


### PR DESCRIPTION
If the cell has interpreter set, use it over frontmatter. If it's not `dagger shell` don't use Dagger Shell.