### PR TITLE
Daggerize testing including e2e integration tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -8,6 +8,10 @@
 !tests/**/*.tsx
 !tests/**/*.js
 !tests/**/*.jsx
+!dagger/**/*.ts
+!dagger/**/*.tsx
+!dagger/**/*.js
+!dagger/**/*.jsx
 
 out
 node_modules

--- a/BUILD.md
+++ b/BUILD.md
@@ -59,3 +59,13 @@ echo "Exporting extension to $EXTENSION_VSIX"
 ### Exported in runme.dev as ExtensionVsix
 Extension | export $EXTENSION_VSIX
 ```
+
+## Testing
+
+```sh {"terminalRows":"35"}
+. --source . | test --debug $(KernelBinary) | directory "tests/e2e/logs" | export /tmp/e2e-logs
+```
+
+```sh {"background":"false","interactive":"true","interpreter":"dagger shell --progress=plain","terminalRows":"38"}
+. --source . | test $(KernelBinary)
+```

--- a/BUILD.md
+++ b/BUILD.md
@@ -3,7 +3,7 @@ runme:
   id: 01JMMSSHXM7N70W4KCJ5XGEE2A
   version: v3
 shell: dagger shell
-terminalRows: 20
+terminalRows: 30
 ---
 
 # Build the Runme VS Code extension (via Dagger)
@@ -40,7 +40,7 @@ The previous command will list all the available platforms per version. Let's pi
 RunmeKernel | release-files --version latest $TARGET_PLATFORM
 ```
 
-## Build the Runme VS Code Extension
+## Build the Extension
 
 Let's tie together above's artifacts via their respective cell names to build the Runme VS Code extension.
 
@@ -57,15 +57,25 @@ echo "Exporting extension to $EXTENSION_VSIX"
 
 ```sh {"name":"ExtensionVsix"}
 ### Exported in runme.dev as ExtensionVsix
-Extension | export $EXTENSION_VSIX
+Extension | bundle | export $EXTENSION_VSIX
 ```
 
 ## Testing
 
-```sh {"terminalRows":"35"}
-. --source . | test --debug $(KernelBinary) | directory "tests/e2e/logs" | export /tmp/e2e-logs
-```
+First let's run the unit tests. They give us fast feedback.
 
 ```sh
-. --source . | test $(KernelBinary) | stdout
+Extension | unit-test | stdout
+```
+
+Then, let's run the end-to-end tests. These require a X server frame buffer which is provided by `xvfb-run` on "native" Linux. These take a good while to finish but mimic extension users closely.
+
+```sh
+Extension | e2e-test | stdout
+```
+
+If they fail, you can re-run them with the `--debug` flag and grab logs and screenshots inside of `tests/e2e/logs`.
+
+```sh {"terminalRows":"35"}
+Extension | e2e-test --debug | directory "tests/e2e/logs" | export /tmp/e2e-logs
 ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -66,6 +66,6 @@ Extension | export $EXTENSION_VSIX
 . --source . | test --debug $(KernelBinary) | directory "tests/e2e/logs" | export /tmp/e2e-logs
 ```
 
-```sh {"background":"false","interactive":"true","interpreter":"dagger shell --progress=plain","terminalRows":"38"}
-. --source . | test $(KernelBinary)
+```sh
+. --source . | test $(KernelBinary) | stdout
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ then ensure to install all project dependencies. Note GitHub token is required t
 ```sh {"id":"01HF7VQMH8ESX1EFV4P491H696","name":"setup","promptEnv":"false"}
 $ export GITHUB_REF_NAME=$(git branch --show-current)
 $ export GITHUB_TOKEN=$(gh auth token)
-$ export EXTENSION_BASENAME=$(node -p 'process.cwd().split("/").pop().split("-")[1]')
+$ export EXTENSION_BASENAME=$(node -p 'let p = process.cwd().split("/").pop().split("-"); p[p.length-1]')
 $ cp -f "assets/$EXTENSION_BASENAME-icon.gif" "assets/icon.gif"
 $ cp -f "assets/$EXTENSION_BASENAME-logo-open-dark.svg" "assets/logo-open-dark.svg"
 $ cp -f "assets/$EXTENSION_BASENAME-logo-open-light.svg" "assets/logo-open-light.svg"

--- a/dagger/BUILD.md
+++ b/dagger/BUILD.md
@@ -1,4 +1,5 @@
 ---
+cwd: ..
 runme:
   id: 01JMMSSHXM7N70W4KCJ5XGEE2A
   version: v3
@@ -64,13 +65,15 @@ Extension | bundle | export $EXTENSION_VSIX
 
 First let's run the unit tests. They give us fast feedback.
 
-```sh
+```sh {"name":"UnitTests"}
+### Exported in runme.dev as UnitTests
 Extension | unit-test | stdout
 ```
 
 Then, let's run the end-to-end tests. These require a X server frame buffer which is provided by `xvfb-run` on "native" Linux. These take a good while to finish but mimic extension users closely.
 
-```sh
+```sh {"name":"E2eTests"}
+### Exported in runme.dev as E2eTests
 Extension | e2e-test | stdout
 ```
 

--- a/dagger/BUILD.md
+++ b/dagger/BUILD.md
@@ -72,8 +72,8 @@ Extension | unit-test | stdout
 
 Then, let's run the end-to-end tests. These require a X server frame buffer which is provided by `xvfb-run` on "native" Linux. These take a good while to finish but mimic extension users closely.
 
-```sh {"name":"E2eTests"}
-### Exported in runme.dev as E2eTests
+```sh {"name":"E2ETests"}
+### Exported in runme.dev as E2ETests
 Extension | e2e-test | stdout
 ```
 

--- a/dagger/scripts/presetup.sh
+++ b/dagger/scripts/presetup.sh
@@ -2,4 +2,6 @@ mkdir -p -m 755 /etc/apt/keyrings && wget -qO- https://cli.github.com/packages/g
 && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
 && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
 && apt update \
-&& apt install gh xvfb -y
+&& apt install -y gh libappindicator3-1 libasound2 libatk-bridge2.0-0 libatk1.0-0 libcups2 \
+    libdbus-1-3 libgbm1 libgdk-pixbuf2.0-0 libgtk-3-0 libnspr4 libnss3 \
+    libpangocairo-1.0-0 libxcomposite1 libxrandr2 libxss1 xvfb

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -94,16 +94,16 @@ export class VscodeRunme {
    * Test the extension end-to-end.
    */
   @func()
-  async test(runmeBinary: Directory, debug = false): Promise<Container> {
-    const e2eTestCommand = [
-      'xvfb-run',
-      'npx wdio run ./tests/e2e/wdio.conf.ts',
-      // '--spec tests/e2e/specs/basic.e2e.ts',
-    ].join(' ')
+  async test(runmeBinary: Directory, debug = false, spec?: string): Promise<Container> {
+    const e2eTestCommand = ['xvfb-run', 'npx wdio run ./tests/e2e/wdio.conf.ts']
+
+    if (spec && spec.length > 0) {
+      e2eTestCommand.push(...['--spec ', spec])
+    }
 
     const build = await this.build(runmeBinary)
     const expect = debug ? ReturnType.Any : ReturnType.Success
 
-    return build.withExec(e2eTestCommand.split(' '), { expect })
+    return build.withExec(e2eTestCommand.join(' ').split(' '), { expect })
   }
 }

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -4,7 +4,6 @@
  *
  */
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {
   Platform,
   dag,
@@ -16,7 +15,6 @@ import {
   ReturnType,
 } from '@dagger.io/dagger'
 @object()
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export class VscodeRunme {
   /**
    * The source to build the extension from.

--- a/dagger/src/index.ts
+++ b/dagger/src/index.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-len */
 /**
  * Build the Runme VS Code extension end-to-end.
  *

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -303,7 +303,7 @@ export const config: Options.Testrunner = {
     }
 
     console.log('Capturing screenshot for debugging')
-    const screenshotDir = path.join(__dirname, 'screenshots')
+    const screenshotDir = path.join(__dirname, 'logs', 'screenshots')
     await fs.mkdir(screenshotDir, { recursive: true })
     await browser.saveScreenshot(path.join(screenshotDir, `${test.parent} - ${test.title}.png`))
   },


### PR DESCRIPTION
This PR makes `runme run UnitTests` & `runme run IntegrationTests` available. The latter will only work on a Linux system that's capable of running virtual X frame buffer (aka `xvfb`).

Once this is merged, we'll start on migrating CI/CD to it.