### PR TITLE
Expand Dagger module to include pre-built extensions

### DIFF
--- a/dagger/BUILD.md
+++ b/dagger/BUILD.md
@@ -105,18 +105,18 @@ Extension | integration-test --debug --runme-test-token RUNME_TEST_TOKEN --spec 
 
 ### Releases
 
-```sh {"terminalRows":"14"}
-. | list-release | entries
-```
-
-```sh {"name":"ReleaseVsix","terminalRows":"12"}
-### Exported in runme.dev as ReleaseVsix
-# . | link-release --version 3.13.3-edge.0 $TARGET_PLATFORM
-. | link-release --version latest $TARGET_PLATFORM
-```
-
 ```sh
-VscodeRunme | prebuild $(ReleaseVsix) |
-  integration-test --spec "specs/bare.e2e.ts" |
+. | list-release --version prerelease | entries
+```
+
+```sh {"name":"PreReleaseVsix"}
+### Exported in runme.dev as PreReleaseVsix
+. | link-release --version prerelease $TARGET_PLATFORM
+```
+
+```sh {"name":"PreReleaseIntegrationTests"}
+### Exported in runme.dev as PreReleaseIntegrationTests
+VscodeRunme | prebuild $(PreReleaseVsix) |
+   --runme-test-token RUNME_TEST_TOKEN
   stdout
 ```

--- a/dagger/BUILD.md
+++ b/dagger/BUILD.md
@@ -109,6 +109,14 @@ Extension | integration-test --debug --runme-test-token RUNME_TEST_TOKEN --spec 
 . | list-release | entries
 ```
 
-```sh {"terminalRows":"10"}
-. | link-release --version 3.13.3-edge.0 $TARGET_PLATFORM | name
+```sh {"name":"ReleaseVsix","terminalRows":"12"}
+### Exported in runme.dev as ReleaseVsix
+# . | link-release --version 3.13.3-edge.0 $TARGET_PLATFORM
+. | link-release --version latest $TARGET_PLATFORM
+```
+
+```sh
+VscodeRunme | prebuild $(ReleaseVsix) |
+  integration-test --spec "specs/bare.e2e.ts" |
+  stdout
 ```

--- a/dagger/BUILD.md
+++ b/dagger/BUILD.md
@@ -117,6 +117,6 @@ Extension | integration-test --debug --runme-test-token RUNME_TEST_TOKEN --spec 
 ```sh {"name":"PreReleaseIntegrationTests"}
 ### Exported in runme.dev as PreReleaseIntegrationTests
 VscodeRunme | prebuild $(PreReleaseVsix) |
-   --runme-test-token RUNME_TEST_TOKEN
+  integration-test --runme-test-token RUNME_TEST_TOKEN |
   stdout
 ```

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -6,7 +6,8 @@ import { Key } from 'webdriverio'
 import type { Options } from '@wdio/types'
 
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
-const extensionPath = path.join(__dirname, '..', '..')
+const workspacePath = path.join(__dirname, '..', '..')
+const extensionPath = process.env.RUNME_TEST_EXTENSION || workspacePath
 
 export const config: Options.Testrunner = {
   //
@@ -95,8 +96,8 @@ export const config: Options.Testrunner = {
       browserVersion: 'stable',
       'wdio:vscodeOptions': {
         extensionPath,
-        workspacePath: extensionPath,
-        filePath: path.join(extensionPath, 'tests', 'fixtures', 'README.md'),
+        workspacePath,
+        filePath: path.join(workspacePath, 'tests', 'fixtures', 'README.md'),
         userSettings: {
           'terminal.integrated.defaultProfile.osx': 'bash',
         },


### PR DESCRIPTION
Make it possible to run tests against a complete build or prebuilds downloaded from GitHub.