### PR TITLE
Run e2e tests against a newer vscode version (not stable yet)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,7 +103,7 @@
         "unzipper": "^0.12.3",
         "vitest": "^3.2.4",
         "vscode-uri": "^3.0.7",
-        "wdio-vscode-service": "^6.1.3",
+        "wdio-vscode-service": "^6.1.4",
         "webdriverio": "^8.40.5",
         "webpack": "^5.100.2",
         "webpack-cli": "^6.0.1"
@@ -24118,9 +24118,9 @@
       }
     },
     "node_modules/wdio-vscode-service": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-6.1.3.tgz",
-      "integrity": "sha512-gBS5JyQYe4GEO4ja9MgMy3M2QkOpFnECz38eIO5g6AkEPtg+5rfq8HvnC5qnKaDg/i5rbtU+AKluLgHVwDKFOA==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-6.1.4.tgz",
+      "integrity": "sha512-doPxz6YzwcQ9V8BEdxk+3gvqRzkA1D3XkqyDV+8WczBtc4KhbkPvwxfB0LUPB/7D9RA3we+gOoIhbISzELIr/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -24135,6 +24135,7 @@
         "fastify": "^4.26.1",
         "get-port": "7.0.0",
         "hpagent": "^1.2.0",
+        "semver": "^7.7.2",
         "slash": "^5.1.0",
         "tmp-promise": "^3.0.3",
         "undici": "^5.28.3",

--- a/package.json
+++ b/package.json
@@ -1469,7 +1469,7 @@
     "unzipper": "^0.12.3",
     "vitest": "^3.2.4",
     "vscode-uri": "^3.0.7",
-    "wdio-vscode-service": "^6.1.3",
+    "wdio-vscode-service": "^6.1.4",
     "webdriverio": "^8.40.5",
     "webpack": "^5.100.2",
     "webpack-cli": "^6.0.1"

--- a/tests/e2e/package-lock.json
+++ b/tests/e2e/package-lock.json
@@ -14,7 +14,7 @@
         "expect-webdriverio": "^4.15.4",
         "runme": "^3.0.1",
         "ts-node": "^10.9.1",
-        "wdio-vscode-service": "^6.1.2",
+        "wdio-vscode-service": "^6.1.4",
         "webdriverio": "^8.39.1"
       }
     },
@@ -6751,25 +6751,12 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -7663,9 +7650,10 @@
       }
     },
     "node_modules/wdio-vscode-service": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-6.1.2.tgz",
-      "integrity": "sha512-qOXpu8SwxPuBUPaZ+1d5j/RKU5JiZQeu5Kcp5iAxwaCj05h4v7TJhexeNYAhHgKqL/7C0uEFzjYWcB3afmDGpw==",
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/wdio-vscode-service/-/wdio-vscode-service-6.1.4.tgz",
+      "integrity": "sha512-doPxz6YzwcQ9V8BEdxk+3gvqRzkA1D3XkqyDV+8WczBtc4KhbkPvwxfB0LUPB/7D9RA3we+gOoIhbISzELIr/A==",
+      "license": "MIT",
       "dependencies": {
         "@fastify/cors": "^9.0.1",
         "@fastify/static": "^7.0.1",
@@ -7678,6 +7666,7 @@
         "fastify": "^4.26.1",
         "get-port": "7.0.0",
         "hpagent": "^1.2.0",
+        "semver": "^7.7.2",
         "slash": "^5.1.0",
         "tmp-promise": "^3.0.3",
         "undici": "^5.28.3",
@@ -8143,11 +8132,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/tests/e2e/package.json
+++ b/tests/e2e/package.json
@@ -12,7 +12,7 @@
     "expect-webdriverio": "^4.15.4",
     "runme": "^3.0.1",
     "ts-node": "^10.9.1",
-    "wdio-vscode-service": "^6.1.2",
+    "wdio-vscode-service": "^6.1.4",
     "webdriverio": "^8.39.1"
   }
 }

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -9,7 +9,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const workspacePath = path.join(__dirname, '..', '..')
 const extensionPath = process.env.RUNME_TEST_EXTENSION || workspacePath
 const specFileRetries = Number(process.env.RUNME_TEST_SPEC_RETRIES) ?? 1
-const browserVersion = process.env.RUNME_TEST_VSCODE_VERSION || '1.99.3'
+const browserVersion = process.env.RUNME_TEST_VSCODE_VERSION || 'stable'
 
 export const config: Options.Testrunner = {
   //

--- a/tests/e2e/wdio.conf.ts
+++ b/tests/e2e/wdio.conf.ts
@@ -9,7 +9,7 @@ const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const workspacePath = path.join(__dirname, '..', '..')
 const extensionPath = process.env.RUNME_TEST_EXTENSION || workspacePath
 const specFileRetries = Number(process.env.RUNME_TEST_SPEC_RETRIES) ?? 1
-const browserVersion = process.env.RUNME_TEST_VSCODE_VERSION || 'stable'
+const browserVersion = process.env.RUNME_TEST_VSCODE_VERSION || '1.102.3'
 
 export const config: Options.Testrunner = {
   //


### PR DESCRIPTION
The upstream library was merged and released https://github.com/webdriverio-community/wdio-vscode-service/pull/150